### PR TITLE
added AppiumClient support and update stf client

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,8 @@ Execution
 ```
 > pytest sample/test_samples.py --stf_host localhost --stf_token $TOKEN --phone_requirements platform=Android
 ```
+
+custom capabilities:
+```
+> pytest --appium_capabilities cab=val1&cab=val2
+```

--- a/README.md
+++ b/README.md
@@ -37,15 +37,27 @@ prepare remote adb connection and starts appium server that tests could utilize 
 ## Usage example
 
 Test script: sample.py
+
 ```python
-def test_create(selected_phone):
-    device, adb, appium = selected_phone
+
+from appium.webdriver.webdriver import WebDriver
+
+
+def test_create(appium_client):
+    client, appium, adb, phone = appium_client
     # device is dictionary of device metadata
     # adb: AdbServer instance, that is already connected
     # appium: AppiumServer instance that provide server address for appium client
-    print(device)
-    print(f'wd_hub: {appium.get_wd_hub_uri()}')
+    print(phone)
+    print(f'wd_hub: {appium.get_api_path()}')
     
+    client: WebDriver
+    client, *_ = appium_client
+    URL = 'https://google.com'
+    client.get(URL)
+    url = client.current_url
+    assert url == URL, 'Wrong URL'
+
 ```
 
 Execution

--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ def test_create(appium_client):
     client.get(URL)
     url = client.current_url
     assert url == URL, 'Wrong URL'
-
 ```
 
 Execution
 ```
 > pytest sample/test_samples.py --stf_host localhost --stf_token $TOKEN --phone_requirements platform=Android
 ```
+
+
+See more examples from [sample/test_samples.py](sample/test_samples.py).
 
 custom capabilities:
 ```

--- a/pytest_stf/plugin.py
+++ b/pytest_stf/plugin.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from stf_appium_client import StfClient
+from stf_appium_client.StfClient import StfClient
 from stf_appium_client.tools import parse_requirements
 from stf_appium_client.AdbServer import AdbServer
 from stf_appium_client.AppiumServer import AppiumServer
@@ -145,4 +145,5 @@ def fixture_appium_client(appium_server, capabilities):
     appium, adb, phone = appium_server
     client = AppiumClient(command_executor=appium.get_api_path(), **capabilities)
     with client as driver:
+        driver: WebDriver
         yield driver, appium, adb, phone

--- a/pytest_stf/plugin.py
+++ b/pytest_stf/plugin.py
@@ -29,7 +29,7 @@ def pytest_addoption(parser):
     )
     group.addoption(
         "--stf_allocation_timeout",
-        default=10,
+        default=1000,
         help="Allocation timeout",
     )
 
@@ -58,11 +58,28 @@ def pytest_unconfigure(config):
         del config._openstf  # pylint: disable=protected-access
 
 
-@pytest.fixture(name="selected_phone", scope="session")
-def fixture_selected_phone(pytestconfig):
+@pytest.fixture(name='allocated_phone', scope="session")
+def fixture_allocated_phone(pytestconfig):
     """
-    Allocate required phone, create ADB tunnel to phone via STF and start appium server for tests.
-    Yields tuple (device: dict, adb: AdbServer, appium: Appium)
+    Allocate required phone via STF.
+    Yields device details as dict.
+    e.g.
+    {
+        "abi": "arm64-v8a",
+        "airplaneMode": false,
+        "battery": {...},
+        "browser": {...},
+        "cpuPlatform": "...",
+        "manufacturer": "...",
+        "marketName": "Pixel 4",
+        "model": "Pixel 4",
+        "network": {...},
+        "platform": "Android",
+        "sdk": "32",
+        "serial": "...",
+        "version": "12",
+        ...
+    }
     """
     assert hasattr(pytestconfig, '_openstf'), 'stf_host or stf_token missing'
 
@@ -74,6 +91,48 @@ def fixture_selected_phone(pytestconfig):
     requirements = parse_requirements(requirements)
 
     with stf.allocation_context(requirements, timeout_seconds=timeout) as device:
-        with AdbServer(device['remote_adb_url']) as adb:
-            with Appium() as appium:
-                yield device, adb, appium
+        yield device
+
+
+@pytest.fixture(name='phone_with_adb', scope="session")
+def fixture_phone_with_adb(allocated_phone):
+    """
+    Allocate required phone and create ADB tunnel to phone via STF.
+    Yields tuple (adb: AdbServer, device: dict)
+    """
+    with AdbServer(allocated_phone['remote_adb_url']) as adb:
+        yield allocated_phone, adb
+
+
+@pytest.fixture(name="appium_server", scope="session")
+def fixture_appium_server(phone_with_adb):
+    """
+    Allocate required phone, create ADB tunnel to phone via STF and start appium server for tests.
+    Yields tuple (appium: Appium, adb: AdbServer, device: dict )
+    """
+    phone, adb = phone_with_adb
+    with Appium() as appium:
+        yield appium, adb, phone
+
+
+@pytest.fixture(name='capabilities')
+def fixture_capabilities(pytestconfig, allocated_phone):
+    capabilities = {
+        "platformName": allocated_phone['platform'],
+        'udid': allocated_phone['serial'],
+    }
+    yield capabilities
+
+@pytest.fixture(name="appium_client", scope="session")
+def fixture_appium_client(appium_server, capabilities):
+    yield appium, adb, phone
+
+
+@pytest.fixture(name="selected_phone", scope="session")
+def fixture_selected_phone(appium_server):
+    """
+    Alternative for appium_server -fixture except tuple is in different order:
+    (device, adb, appium)
+    """
+    appium, adb, device = appium_server
+    yield device, adb, appium

--- a/sample/test_samples.py
+++ b/sample/test_samples.py
@@ -1,4 +1,28 @@
-def test_create(selected_phone):
-    device, adb, appium = selected_phone
-    print(device)
+from time import sleep
+from appium import webdriver
+from appium.options.android import UiAutomator2Options
+
+def test_adb(phone_with_adb):
+    phone, adb = phone_with_adb
+    print(phone)
+    sleep(100)
+
+
+def test_appium(appium_server):
+    appium, adb, phone = appium_server
+    print(phone)
+    #print(adb._execute('devices'))
     print(f'wd_hub: {appium.get_wd_hub_uri()}')
+
+
+    options = UiAutomator2Options()
+    options.platform_name = phone['platform']
+    options.platform_Version = phone['version']
+    #options.udid = phone['serial']
+    options.set_capability("browser_name", "Browser")
+    driver = webdriver.Remote(appium.get_wd_hub_uri(), options=options)
+
+    print(driver)
+
+    driver.quit()
+

--- a/sample/test_samples.py
+++ b/sample/test_samples.py
@@ -1,28 +1,38 @@
-from time import sleep
-from appium import webdriver
-from appium.options.android import UiAutomator2Options
+from appium.webdriver.webdriver import WebDriver
+
+from stf_appium_client import AppiumServer, AdbServer
+
+
+def test_allocated_phone(allocated_phone: dict):
+    # allocated_phone is dictionary of phone metadata
+    print(allocated_phone)
+
 
 def test_adb(phone_with_adb):
-    phone, adb = phone_with_adb
-    print(phone)
-    sleep(100)
+    # allocated phone with adb proxy
+    adb, phone = phone_with_adb
+    adb: AdbServer
+    response = adb._execute('shell getprop ro.build.version.release', 10)
+    assert response.stdout == phone.get('version'), 'Wrong Android version'
 
 
 def test_appium(appium_server):
+    # allocated phone with adb and appium server
     appium, adb, phone = appium_server
-    print(phone)
-    #print(adb._execute('devices'))
-    print(f'wd_hub: {appium.get_wd_hub_uri()}')
+    appium: AppiumServer
+    print(f'wd_hub: {appium.get_api_path()}')
 
 
-    options = UiAutomator2Options()
-    options.platform_name = phone['platform']
-    options.platform_Version = phone['version']
-    #options.udid = phone['serial']
-    options.set_capability("browser_name", "Browser")
-    driver = webdriver.Remote(appium.get_wd_hub_uri(), options=options)
+def test_client(appium_client):
+    # allocated phone with adb+appium server + appium client (WebDriver)
+    client, appium, adb, phone = appium_client
 
-    print(driver)
+    # adb: AdbServer instance, that is already connected
+    # appium: AppiumServer instance that provide server address for appium client
+    #
+    client: WebDriver
+    test_url = 'https://google.com'
 
-    driver.quit()
-
+    client.get(test_url)
+    url = client.current_url
+    assert url == test_url, 'Wrong URL'

--- a/sample/test_samples.py
+++ b/sample/test_samples.py
@@ -1,3 +1,4 @@
+import pytest
 from appium.webdriver.webdriver import WebDriver
 
 from stf_appium_client import AppiumServer, AdbServer
@@ -23,16 +24,43 @@ def test_appium(appium_server):
     print(f'wd_hub: {appium.get_api_path()}')
 
 
+@pytest.fixture(scope='session')
+def fixture_capabilities(pytestconfig):
+    values = pytestconfig.getoption('appium_capabilities')
+
+
+@pytest.fixture(name='appium_args', scope='session')
+def fixture_appium_args():
+    # overridable list of appium server args
+    # https://appium.io/docs/en/writing-running-appium/server-args/
+    return []
+
+
+@pytest.fixture(name='capabilities', scope='session')
+def fixture_capabilities(pytestconfig, allocated_phone):
+    # Allows to overwrite WebDriver arguments
+    # Under the hoods these are used like `WebDriver(**kwargs)`
+    kwargs = {
+        "desired_capabilities": {
+            'platformName': allocated_phone['platform'],
+            #'udid': '', #allocated_phone['serial'],
+            'automationName': 'UiAutomator2',
+            'browserName': 'Chrome',
+        }
+    }
+    yield kwargs
+
+
 def test_client(appium_client):
     # allocated phone with adb+appium server + appium client (WebDriver)
-    client, appium, adb, phone = appium_client
+    driver, appium, adb, phone = appium_client
 
     # adb: AdbServer instance, that is already connected
     # appium: AppiumServer instance that provide server address for appium client
     #
-    client: WebDriver
+    driver: WebDriver
     test_url = 'https://google.com'
 
-    client.get(test_url)
-    url = client.current_url
+    driver.get(test_url)
+    url = driver.current_url
     assert url == test_url, 'Wrong URL'

--- a/sample/test_samples.py
+++ b/sample/test_samples.py
@@ -59,7 +59,7 @@ def test_client(appium_client):
     # appium: AppiumServer instance that provide server address for appium client
     #
     driver: WebDriver
-    test_url = 'https://google.com'
+    test_url = 'https://www.google.com/'
 
     driver.get(test_url)
     url = driver.current_url

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=[
         "pytest>=5.0",
         "pytest-metadata",
-        "stf-appium-client==0.7.0"],
+        "stf-appium-client==0.8.0"],
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"
     # syntax, for example:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=[
         "pytest>=5.0",
         "pytest-metadata",
-        "stf-appium-client==0.8.1"],
+        "stf-appium-client==0.9.0"],
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"
     # syntax, for example:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=[
         "pytest>=5.0",
         "pytest-metadata",
-        "stf-appium-client==0.8.0"],
+        "stf-appium-client==0.8.1"],
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"
     # syntax, for example:


### PR DESCRIPTION
based on https://github.com/OpenTMI/stf-appium-python-client/pull/16 and  https://github.com/OpenTMI/stf-appium-python-client/pull/17

Depends on https://pypi.org/project/stf-appium-client/0.8.1/ and https://pypi.org/project/stf-client/0.1.0/

BREAKING CHANGE. no more `selected_phone` fixture.

new fixtures:
* `allocated_phone`
  * uses arguments like `--phone_requirements` and `--stf_allocation_timeout`
  * returns dictionary of allocated phone details
* `phone_with_adb `
  * returns AdbServer object 
* `appium_args`
  * overridable arguments for Appium server
* `appium_server`
  * returns AppiumServer object 
* `capabilities`
  * overridable WebDriver arguments
* `appium_client`
  * returns WebDriver instance  